### PR TITLE
feat: set the openai base url

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,2 +1,4 @@
 TWITTER_AUTH_TOKEN = 'YOUR_TWITTER_AUTH_TOKEN_HERE'
 OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY_HERE'
+# set the openai base url, if the value is None, it will use the default base url
+OPENAI_BASE_URL = None

--- a/twitter_data_initial_exploration.ipynb
+++ b/twitter_data_initial_exploration.ipynb
@@ -6705,7 +6705,7 @@
    "outputs": [],
    "source": [
     "from openai import OpenAI\n",
-    "from config import OPENAI_API_KEY\n",
+    "from config import OPENAI_API_KEY, OPENAI_BASE_URL\n",
     "import os \n",
     "import json\n",
     "from IPython.display import Image, display\n",
@@ -6713,6 +6713,9 @@
     "if \"OPENAI_API_KEY\" not in os.environ:\n",
     "    os.environ[\"OPENAI_API_KEY\"] = OPENAI_API_KEY\n",
     "\n",
+    "if \"OPENAI_BASE_URL\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_BASE_URL\"] = OPENAI_BASE_URL\n",
+    "    \n",
     "client = OpenAI()\n",
     "\n",
     "def get_valid_json_with_gpt35(input):\n",


### PR DESCRIPTION
Sometimes we use custom api, so we need to manually set the `OPENAI_BASE_URL`.
if the value is None, it will use the default base url.
